### PR TITLE
pinning numpy from prior to latest release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy==1.26.0
 pyxdg
 coloredlogs
 pandas<=1.5


### PR DESCRIPTION
Numpy introduced some breaking changes with their 2.0.0 release.

Given that numpy is used for math rather than security, I figure it's safe to pin.

Fixes https://github.com/neuropoly/neuro.polymtl.ca/issues/95